### PR TITLE
Updates needed for Moodle 4.2+

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -17,7 +17,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
       mariadb:
         # https://tracker.moodle.org/browse/MDL-72131
-        image: mariadb:10.5
+        image: mariadb:10
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
@@ -28,23 +28,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4', '8.0']
-        moodle-branch: ['MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'MOODLE_401_STABLE']
-        database: ['pgsql', 'mariadb']
-        extensions: ["mbstring, pgsql, mysqli"]
-        # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-new-combinations
         include:
-          - moodle-branch: 'MOODLE_401_STABLE'
-            php: '8.1'
+          - php: '8.1'
+            moodle-branch: 'master'
             extensions: "mbstring, pgsql, mysqli"
             database: 'pgsql'
-          - moodle-branch: 'MOODLE_401_STABLE'
-            php: '8.1'
+          - php: '8.0'
+            moodle-branch: 'MOODLE_402_STABLE'
             extensions: "mbstring, pgsql, mysqli"
             database: 'mariadb'
-        exclude:
-          - php: '7.3'
-            moodle-branch: 'MOODLE_401_STABLE'
 
     steps:
       - name: Check out repository code

--- a/classes/event/user_merged.php
+++ b/classes/event/user_merged.php
@@ -52,20 +52,4 @@ abstract class user_merged extends \core\event\base {
         $this->data['level'] = self::LEVEL_OTHER; // fixing backwards compatibility
         $this->data['edulevel'] = self::LEVEL_OTHER;
     }
-
-    /**
-     * It will allow legacy plugins to continue to listen user_merged events
-     * without upgrading their listeners.
-     *
-     * @return \stdClass legacy object
-     */
-    protected function get_legacy_eventdata() {
-        $data = new \stdClass();
-        $userinvolded = $this->other['usersinvolved'];
-        $data->newid = $userinvolded['toid'];
-        $data->oldid = $userinvolded['fromid'];
-        $data->log = $this->other['log'];
-        $data->timemodified = $this->timecreated;
-        return $data;
-    }
 }

--- a/classes/event/user_merged_failure.php
+++ b/classes/event/user_merged_failure.php
@@ -41,10 +41,6 @@ class user_merged_failure extends user_merged {
         return get_string('eventusermergedfailure', 'tool_mergeusers');
     }
 
-    public static function get_legacy_eventname() {
-        return 'merging_failed';
-    }
-
     public function get_description() {
         return "The user {$this->userid} tried to merge all user-related data records
             from '{$this->other['usersinvolved']['fromid']}' into '{$this->other['usersinvolved']['toid']}' but faild";

--- a/classes/event/user_merged_success.php
+++ b/classes/event/user_merged_success.php
@@ -41,10 +41,6 @@ class user_merged_success extends user_merged {
         return get_string('eventusermergedsuccess', 'tool_mergeusers');
     }
 
-    public static function get_legacy_eventname() {
-        return 'merging_success';
-    }
-
     public function get_description() {
         return "The user {$this->userid} merged all user-related data
             from '{$this->other['usersinvolved']['fromid']}' into '{$this->other['usersinvolved']['toid']}'";

--- a/lib/table/quizattemptsmerger.php
+++ b/lib/table/quizattemptsmerger.php
@@ -15,6 +15,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+use mod_quiz\grade_calculator;
+use mod_quiz\quiz_settings;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -85,8 +88,8 @@ class QuizAttemptsMerger extends GenericTableMerger
     }
 
     /**
-     * This TableMerger processes quiz_attempts accordingly, regrading when 
-     * necessary. So that tables quiz_grades and quiz_grades_history 
+     * This TableMerger processes quiz_attempts accordingly, regrading when
+     * necessary. So that tables quiz_grades and quiz_grades_history
      * have to be omitted from processing by other TableMergers.
      *
      * @return array
@@ -128,7 +131,7 @@ class QuizAttemptsMerger extends GenericTableMerger
 
     /**
      * Merges the records related to the given users given in $data,
-     * updating/appending the list of $errorMessages and $actionLog, 
+     * updating/appending the list of $errorMessages and $actionLog,
      * by having the union of all attempts and being renumbered by
      * the timestart of each attempt.
      *
@@ -187,19 +190,19 @@ class QuizAttemptsMerger extends GenericTableMerger
 
                 // Now we know that we have to gather all attempts and renumber them
                 // by their timestart.
-                // 
-                // In order to prevent key collisions for (userid, quiz and attempt), 
+                //
+                // In order to prevent key collisions for (userid, quiz and attempt),
                 // we adopt the following procedure:
-                // 
+                //
                 //   1. Renumber all attempts updating their attempt to $max + $nattempt.
                 //   2. Update all above attempts to subtract $max to their attempt value.
-                //   
+                //
                 // In step 1. we have $max set to the total number of attempts from both
                 // users, and $nattempt is just an incremental value.
-                // 
+                //
                 // In step 2. we renumber all attempts to start from 1 by just subtracting
                 // the $max value to their attempt column.
-                // 
+                //
                 //
                 // total number of attempts from both users.
                 $max = count($attempts);
@@ -251,7 +254,7 @@ class QuizAttemptsMerger extends GenericTableMerger
 
     /**
      * Overriding the default implementation to add a final task: updateQuizzes.
-     * 
+     *
      * @param array $data array with details of merging.
      * @param array $recordsToModify list of record ids to update with $toid.
      * @param string $fieldName field name of the table to update.
@@ -301,7 +304,8 @@ class QuizAttemptsMerger extends GenericTableMerger
             foreach ($quizzes as $quiz) {
                 // https://moodle.org/mod/forum/discuss.php?d=258979
                 // recalculate grades for affected quizzes.
-                quiz_update_all_final_grades($quiz);
+                $quizobj = quiz_settings::create($quiz->id);
+                $quizobj->get_grade_calculator()->recompute_all_final_grades();
             }
         }
     }

--- a/tests/assign_submission_duplicated_test.php
+++ b/tests/assign_submission_duplicated_test.php
@@ -24,7 +24,7 @@ defined('MOODLE_INTERNAL') || die();
 require_once(__DIR__ . '/../lib/db/inmemoryfindbyquery.php');
 require_once(__DIR__ . '/../lib/duplicateddata/assignsubmissionduplicateddatamerger.php');
 
-class tool_mergeusers_assign_submission_duplicated_testcase extends advanced_testcase {
+class assign_submission_duplicated_test extends advanced_testcase {
 
     /**
      * Should do nothing with new submission and remove old submission when old user has no content submission

--- a/tests/assign_test.php
+++ b/tests/assign_test.php
@@ -31,7 +31,7 @@ require_once($CFG->dirroot . '/mod/assign/tests/base_test.php');
 /**
  * Class assign_test
  */
-class tool_mergeusers_assign_testcase extends \mod_assign\base_test {
+class assign_test extends \mod_assign\base_test {
     /**
      *
      */

--- a/tests/clioptions_test.php
+++ b/tests/clioptions_test.php
@@ -22,7 +22,7 @@
  * @author     Andrew Hancox <andrewdchancox@googlemail.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_mergeusers_clioptions_testcase extends advanced_testcase {
+class clioptions_test extends advanced_testcase {
 
     public function setUp(): void {
         global $CFG;

--- a/tests/enrolments_test.php
+++ b/tests/enrolments_test.php
@@ -22,7 +22,7 @@
  * @author     Andrew Hancox <andrewdchancox@googlemail.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_mergeusers_enrolments_testcase extends advanced_testcase {
+class enrolments_test extends advanced_testcase {
     /**
      * Setup the test.
      */

--- a/tests/quiz_test.php
+++ b/tests/quiz_test.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+use mod_quiz\quiz_settings;
 
 /**
  * Version information
@@ -22,7 +23,7 @@
  * @author     Andrew Hancox <andrewdchancox@googlemail.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_mergeusers_quiz_testcase extends advanced_testcase {
+class quiz_test extends advanced_testcase {
     /**
      * Configure the test.
      * Create two courses with a quiz in each.
@@ -140,7 +141,7 @@ class tool_mergeusers_quiz_testcase extends advanced_testcase {
      */
     private function submit_quiz_attempt($quiz, $user, $answers) {
         // Create a quiz attempt for the user.
-        $quizobj = quiz::create($quiz->id, $user->id);
+        $quizobj = quiz_settings::create($quiz->id, $user->id);
 
         // Set up and start an attempt.
         $quba = question_engine::make_questions_usage_by_activity('mod_quiz', $quizobj->get_context());
@@ -149,7 +150,7 @@ class tool_mergeusers_quiz_testcase extends advanced_testcase {
         $attempt = quiz_create_attempt($quizobj, 1, false, $timenow, false, $user->id);
         quiz_start_new_attempt($quizobj, $quba, $attempt, 1, $timenow);
         quiz_attempt_save_started($quizobj, $quba, $attempt);
-        $attemptobj = quiz_attempt::create($attempt->id);
+        $attemptobj = \mod_quiz\quiz_attempt::create($attempt->id);
         $attemptobj->process_submitted_actions($timenow, false, $answers);
 
         $timefinish = time();


### PR DESCRIPTION
- using correct test class names
- removed deprecated legacy functions
- updated renamed autoloader class calls
- replaced deprecated function recompute_all_final_grades()
- updated moodle_ci.yml

As this differs from Moodle <= 4.1 I suggest to keep the current 'master' branch as a new 'MOODLE_401_STABLE' branch before merging this.