### PR TITLE
278 Fix Creation of dynamic property

### DIFF
--- a/lib/table/assignsubmissiontablemerger.php
+++ b/lib/table/assignsubmissiontablemerger.php
@@ -27,6 +27,7 @@ require_once(__DIR__ . '/../db/dbassignsubmission.php');
 class AssignSubmissionTableMerger extends GenericTableMerger {
 
     private $findassignsubmissions;
+    private $duplicateddatamerger;
 
     public function __construct() {
         parent::__construct(new AssignSubmissionDuplicatedDataMerger());


### PR DESCRIPTION
Fix the error:

  Creation of dynamic property
  AssignSubmissionTableMerger::$duplicateddatamerger is deprecated

that appeared on admin/tool/mergeusers/index.php.