### PR TITLE
Issue #437: Skip grade items whose component directory is missing

### DIFF
--- a/classes/local/callbacks/regrading_after_merged_callback.php
+++ b/classes/local/callbacks/regrading_after_merged_callback.php
@@ -63,19 +63,27 @@ class regrading_after_merged_callback {
 
         $iteminstances = $DB->get_records_sql($sql, ['itemtype' => 'mod', 'toid' => $hook->toid, 'fromid' => $hook->fromid]);
 
+        // Regrading a single activity makes core regrade every grade item of its course, so one grade item
+        // whose module code is gone breaks the whole course, not just itself. Detect those courses up front.
+        $uninstalledmodules = self::get_uninstalled_modules_per_course(
+            array_unique(array_column($iteminstances, 'courseid'))
+        );
+        $loggedcourses = [];
+
         // Get database manager once for reuse in the loop.
         $dbman = $DB->get_manager();
 
         foreach ($iteminstances as $iteminstance) {
-            // Module registered in the database but its code is gone: regrading it would make core throw
-            // a coding exception from component_callback_exists(). Skip it instead of aborting the merge.
-            if (\core_component::get_component_directory('mod_' . $iteminstance->itemmodule) === null) {
-                $hook->add_log(sprintf(
-                    'Skipped regrading grade item with id "%s" from course "%s": module type "%s" is not installed.',
-                    $iteminstance->id,
-                    $iteminstance->courseid,
-                    $iteminstance->itemmodule,
-                ));
+            if (isset($uninstalledmodules[$iteminstance->courseid])) {
+                if (!isset($loggedcourses[$iteminstance->courseid])) {
+                    $loggedcourses[$iteminstance->courseid] = true;
+                    $hook->add_log(sprintf(
+                        'Skipped regrading course "%s": it has grade items of uninstalled module types (%s), ' .
+                        'which would make the course-wide regrade fail.',
+                        $iteminstance->courseid,
+                        implode(', ', $uninstalledmodules[$iteminstance->courseid]),
+                    ));
+                }
                 continue;
             }
 
@@ -135,5 +143,42 @@ class regrading_after_merged_callback {
                 $hook->add_log(htmlspecialchars($regradeoutput));
             }
         }
+    }
+
+    /**
+     * Finds, for the given courses, the module types that have grade items but are no longer installed.
+     *
+     * @param array $courseids
+     * @return array course id => list of uninstalled module names. Courses without any are not present.
+     * @throws dml_exception
+     */
+    private static function get_uninstalled_modules_per_course(array $courseids): array {
+        global $DB;
+
+        if (empty($courseids)) {
+            return [];
+        }
+
+        [$insql, $params] = $DB->get_in_or_equal($courseids, SQL_PARAMS_NAMED, 'cid');
+        $params['itemtype'] = 'mod';
+        $sql = "SELECT DISTINCT courseid, itemmodule
+                  FROM {grade_items}
+                 WHERE itemtype = :itemtype AND courseid $insql";
+
+        $uninstalled = [];
+        $installed = [];
+        $records = $DB->get_recordset_sql($sql, $params);
+        foreach ($records as $record) {
+            if (!isset($installed[$record->itemmodule])) {
+                $installed[$record->itemmodule] =
+                    \core_component::get_component_directory('mod_' . $record->itemmodule) !== null;
+            }
+            if (!$installed[$record->itemmodule]) {
+                $uninstalled[$record->courseid][$record->itemmodule] = $record->itemmodule;
+            }
+        }
+        $records->close();
+
+        return $uninstalled;
     }
 }

--- a/classes/local/callbacks/regrading_after_merged_callback.php
+++ b/classes/local/callbacks/regrading_after_merged_callback.php
@@ -67,6 +67,18 @@ class regrading_after_merged_callback {
         $dbman = $DB->get_manager();
 
         foreach ($iteminstances as $iteminstance) {
+            // Module registered in the database but its code is gone: regrading it would make core throw
+            // a coding exception from component_callback_exists(). Skip it instead of aborting the merge.
+            if (\core_component::get_component_directory('mod_' . $iteminstance->itemmodule) === null) {
+                $hook->add_log(sprintf(
+                    'Skipped regrading grade item with id "%s" from course "%s": module type "%s" is not installed.',
+                    $iteminstance->id,
+                    $iteminstance->courseid,
+                    $iteminstance->itemmodule,
+                ));
+                continue;
+            }
+
             // Check if the plugin table exists (critical: module registered but table missing = corruption).
             if (!$dbman->table_exists($iteminstance->itemmodule)) {
                 throw new moodle_exception(

--- a/tests/regrading_after_merged_callback_test.php
+++ b/tests/regrading_after_merged_callback_test.php
@@ -317,14 +317,144 @@ final class regrading_after_merged_callback_test extends advanced_testcase {
     }
 
     /**
+     * Test that a course containing a grade item whose module code is gone is skipped entirely.
+     *
+     * The module stays registered in {modules} (so the callback's SQL still returns its siblings),
+     * but its code directory is absent. Regrading any activity of that course would make core
+     * regrade every grade item of the course and throw a coding exception from
+     * component_callback_exists(), so the whole course must be skipped.
+     *
+     * @group tool_mergeusers
+     * @group tool_mergeusers_regrade
+     */
+    public function test_regrade_skips_course_with_uninstalled_module_code(): void {
+        // Valid activity that would otherwise be regraded.
+        $this->create_activity_with_grades('assign');
+
+        $this->create_orphaned_grade_item($this->course->id);
+
+        $logs = [];
+        $errors = [];
+        $hook = new after_merged_all_tables($this->user1->id, $this->user2->id, $logs, $errors);
+
+        regrading_after_merged_callback::regrade($hook);
+
+        $this->assertEmpty($errors, 'No errors should be generated');
+
+        $skiplogs = $this->filter_logs($logs, 'Skipped regrading course');
+        $this->assertCount(1, $skiplogs, 'The course should be reported as skipped');
+        $this->assertStringContainsString((string)$this->course->id, $skiplogs[0]);
+        $this->assertStringContainsString('journal', $skiplogs[0], 'The uninstalled module should be named');
+
+        $this->assertEmpty(
+            $this->filter_logs($logs, 'Regraded grade item'),
+            'No grade item of the affected course should be regraded'
+        );
+    }
+
+    /**
+     * Test that skipping a broken course does not stop other courses from being regraded.
+     *
+     * @group tool_mergeusers
+     * @group tool_mergeusers_regrade
+     */
+    public function test_regrade_continues_with_other_courses_when_one_is_skipped(): void {
+        $othercourse = $this->getDataGenerator()->create_course();
+        $this->getDataGenerator()->enrol_user($this->user1->id, $othercourse->id);
+        $this->getDataGenerator()->enrol_user($this->user2->id, $othercourse->id);
+
+        $this->create_activity_with_grades('assign', 'Broken course assignment');
+        $this->create_orphaned_grade_item($this->course->id);
+        $this->create_activity_with_grades('assign', 'Healthy course assignment', $othercourse);
+
+        $logs = [];
+        $errors = [];
+        $hook = new after_merged_all_tables($this->user1->id, $this->user2->id, $logs, $errors);
+
+        regrading_after_merged_callback::regrade($hook);
+
+        $this->assertEmpty($errors, 'No errors should be generated');
+        $this->assertCount(1, $this->filter_logs($logs, 'Skipped regrading course'));
+
+        $regradelogs = $this->filter_logs($logs, 'Regraded grade item');
+        $this->assertCount(1, $regradelogs, 'Only the healthy course should be regraded');
+        $this->assertStringContainsString(
+            'from course "' . $othercourse->id . '"',
+            $regradelogs[0],
+            'The regraded item should belong to the healthy course'
+        );
+    }
+
+    /**
+     * Test that a skipped course is reported once, no matter how many grade items it holds.
+     *
+     * @group tool_mergeusers
+     * @group tool_mergeusers_regrade
+     */
+    public function test_regrade_logs_skipped_course_only_once(): void {
+        $this->create_activity_with_grades('assign', 'Assignment 1');
+        $this->create_activity_with_grades('assign', 'Assignment 2');
+        $this->create_orphaned_grade_item($this->course->id);
+
+        $logs = [];
+        $errors = [];
+        $hook = new after_merged_all_tables($this->user1->id, $this->user2->id, $logs, $errors);
+
+        regrading_after_merged_callback::regrade($hook);
+
+        $this->assertCount(
+            1,
+            $this->filter_logs($logs, 'Skipped regrading course'),
+            'The skipped course should be logged once, not once per grade item'
+        );
+        $this->assertEmpty($errors, 'No errors should be generated');
+    }
+
+    /**
+     * Test that an orphaned grade item breaks the course even without grades for the merged users.
+     *
+     * The orphan is found through the course, not through the merged users' grades, so it must
+     * still be detected when only the valid activity has grades for them.
+     *
+     * @group tool_mergeusers
+     * @group tool_mergeusers_regrade
+     */
+    public function test_regrade_detects_orphaned_item_without_grades_for_merged_users(): void {
+        global $DB;
+
+        $this->create_activity_with_grades('assign');
+        $orphanid = $this->create_orphaned_grade_item($this->course->id);
+
+        // Make sure the orphan is unreachable from the callback's own grade_grades lookup.
+        $this->assertEmpty($DB->get_records('grade_grades', ['itemid' => $orphanid]));
+
+        $logs = [];
+        $errors = [];
+        $hook = new after_merged_all_tables($this->user1->id, $this->user2->id, $logs, $errors);
+
+        regrading_after_merged_callback::regrade($hook);
+
+        $this->assertCount(1, $this->filter_logs($logs, 'Skipped regrading course'));
+        $this->assertEmpty($this->filter_logs($logs, 'Regraded grade item'));
+        $this->assertEmpty($errors, 'No errors should be generated');
+    }
+
+    /**
      * Helper method to create an activity with grades for both test users.
      *
      * @param string $modulename Module name (e.g., 'assign', 'data')
      * @param string $activityname Optional activity name
+     * @param object|null $course Course to create the activity in, defaults to the shared one
      * @return object The created activity instance
      */
-    private function create_activity_with_grades(string $modulename, string $activityname = ''): object {
+    private function create_activity_with_grades(
+        string $modulename,
+        string $activityname = '',
+        ?object $course = null
+    ): object {
         global $DB;
+
+        $course = $course ?? $this->course;
 
         if (empty($activityname)) {
             $activityname = ucfirst($modulename) . ' Test';
@@ -335,7 +465,7 @@ final class regrading_after_merged_callback_test extends advanced_testcase {
 
         // Create the activity using create_module (grade_item is auto-created).
         $activity = $this->getDataGenerator()->create_module($modulename, [
-            'course' => $this->course->id,
+            'course' => $course->id,
             'name' => $activityname,
             'grade' => 100, // Enable grading.
         ]);
@@ -345,7 +475,7 @@ final class regrading_after_merged_callback_test extends advanced_testcase {
             'itemtype' => 'mod',
             'itemmodule' => $modulename,
             'iteminstance' => $activity->id,
-            'courseid' => $this->course->id,
+            'courseid' => $course->id,
         ]);
 
         // Create grades for both users if grade item exists.
@@ -355,7 +485,7 @@ final class regrading_after_merged_callback_test extends advanced_testcase {
 
             grade_update(
                 'mod/' . $modulename,
-                $this->course->id,
+                $course->id,
                 'mod',
                 $modulename,
                 $activity->id,
@@ -365,7 +495,7 @@ final class regrading_after_merged_callback_test extends advanced_testcase {
 
             grade_update(
                 'mod/' . $modulename,
-                $this->course->id,
+                $course->id,
                 'mod',
                 $modulename,
                 $activity->id,
@@ -375,5 +505,60 @@ final class regrading_after_merged_callback_test extends advanced_testcase {
         }
 
         return $activity;
+    }
+
+    /**
+     * Creates a grade item for a module that is registered in {modules} but has no code on disk.
+     *
+     * 'journal' is used because it is a real historic Moodle module name that no longer ships with
+     * core, so core_component cannot resolve a directory for it.
+     *
+     * @param int $courseid
+     * @return int The new grade_items.id
+     */
+    private function create_orphaned_grade_item(int $courseid): int {
+        global $DB;
+
+        $this->assertNull(
+            \core_component::get_component_directory('mod_journal'),
+            'This test needs mod_journal to be absent from the codebase'
+        );
+
+        if (!$DB->record_exists('modules', ['name' => 'journal'])) {
+            $DB->insert_record('modules', (object)[
+                'name' => 'journal',
+                'cron' => 0,
+                'lastcron' => 0,
+                'search' => '',
+                'visible' => 1,
+            ]);
+        }
+
+        return $DB->insert_record('grade_items', (object)[
+            'courseid' => $courseid,
+            'itemname' => 'Orphaned journal',
+            'itemtype' => 'mod',
+            'itemmodule' => 'journal',
+            'iteminstance' => 999999,
+            'itemnumber' => 0,
+            'gradetype' => GRADE_TYPE_VALUE,
+            'grademax' => 10,
+            'grademin' => 0,
+            'timecreated' => time(),
+            'timemodified' => time(),
+        ]);
+    }
+
+    /**
+     * Returns the log lines containing the given needle.
+     *
+     * @param array $logs
+     * @param string $needle
+     * @return array
+     */
+    private function filter_logs(array $logs, string $needle): array {
+        return array_values(array_filter($logs, function ($log) use ($needle) {
+            return strpos($log, $needle) !== false;
+        }));
     }
 }

--- a/tests/regrading_after_merged_callback_test.php
+++ b/tests/regrading_after_merged_callback_test.php
@@ -41,6 +41,12 @@ use tool_mergeusers\local\callbacks\regrading_after_merged_callback;
  * @covers    \tool_mergeusers\local\callbacks\regrading_after_merged_callback
  */
 final class regrading_after_merged_callback_test extends advanced_testcase {
+    /**
+     * Synthetic module name used to simulate a module registered in {modules} with no code on disk.
+     * It must never match a real plugin, so it is not any current or historic Moodle module name.
+     */
+    private const MISSINGCODEMODULE = 'tmuphantommod';
+
     /** @var object Course object */
     private object $course;
 
@@ -344,7 +350,7 @@ final class regrading_after_merged_callback_test extends advanced_testcase {
         $skiplogs = $this->filter_logs($logs, 'Skipped regrading course');
         $this->assertCount(1, $skiplogs, 'The course should be reported as skipped');
         $this->assertStringContainsString((string)$this->course->id, $skiplogs[0]);
-        $this->assertStringContainsString('journal', $skiplogs[0], 'The uninstalled module should be named');
+        $this->assertStringContainsString(self::MISSINGCODEMODULE, $skiplogs[0], 'The uninstalled module should be named');
 
         $this->assertEmpty(
             $this->filter_logs($logs, 'Regraded grade item'),
@@ -510,9 +516,6 @@ final class regrading_after_merged_callback_test extends advanced_testcase {
     /**
      * Creates a grade item for a module that is registered in {modules} but has no code on disk.
      *
-     * 'journal' is used because it is a real historic Moodle module name that no longer ships with
-     * core, so core_component cannot resolve a directory for it.
-     *
      * @param int $courseid
      * @return int The new grade_items.id
      */
@@ -520,25 +523,23 @@ final class regrading_after_merged_callback_test extends advanced_testcase {
         global $DB;
 
         $this->assertNull(
-            \core_component::get_component_directory('mod_journal'),
-            'This test needs mod_journal to be absent from the codebase'
+            \core_component::get_component_directory('mod_' . self::MISSINGCODEMODULE),
+            'The synthetic module name must not resolve to a real plugin directory'
         );
 
-        if (!$DB->record_exists('modules', ['name' => 'journal'])) {
-            $DB->insert_record('modules', (object)[
-                'name' => 'journal',
-                'cron' => 0,
-                'lastcron' => 0,
-                'search' => '',
-                'visible' => 1,
-            ]);
-        }
+        $DB->insert_record('modules', (object)[
+            'name' => self::MISSINGCODEMODULE,
+            'cron' => 0,
+            'lastcron' => 0,
+            'search' => '',
+            'visible' => 1,
+        ]);
 
         return $DB->insert_record('grade_items', (object)[
             'courseid' => $courseid,
-            'itemname' => 'Orphaned journal',
+            'itemname' => 'Orphaned grade item',
             'itemtype' => 'mod',
-            'itemmodule' => 'journal',
+            'itemmodule' => self::MISSINGCODEMODULE,
             'iteminstance' => 999999,
             'itemnumber' => 0,
             'gradetype' => GRADE_TYPE_VALUE,


### PR DESCRIPTION
Closes #437.

Added a fix to skip grade items whose component directory is missing before calling `grade_update_mod_grades()` in `regrading_after_merged_callback()`.

**Environment**
```
- Moodle 4.5
- PHP 8.1
- MySQL 8.0
- tool_mergeusers (2026052700: Focus on stability and extensibility)
```
**How to reproduce**
1. On a site that has (or previously had) a third-party activity module with graded activities - `mod_journal` in my case - make sure at least one graded activity of that type exists with grades for two users.
2. Remove the plugin's code directory (`mod/journal/`) without running the uninstall, so the `{modules}` row, the `journal` table and the associated `grade_items` rows remain in the database. This is the state a site ends up in when a plugin is deleted during an upgrade/deployment rather than uninstalled through the UI.
3. Go to *Site administration → Users → Accounts → Merge user accounts*.
4. Select the two users that have grades in the orphaned activity and run the merge.
5. The merge aborts with the exception below; no regrading is performed and the merge is reported as failed.

**Expected Testing Outcome**
- Merge completes with no errors relating to plugin callback
```
Exception thrown when merging: 'Coding error detected, it must be fixed by a programmer: Invalid component used in plugin/component_callback():mod_journal".
```